### PR TITLE
⚠️ Issue with breaking update from third party lib

### DIFF
--- a/Sources/PostgresBridge/PostgresConnectionSource.swift
+++ b/Sources/PostgresBridge/PostgresConnectionSource.swift
@@ -27,7 +27,7 @@ public struct PostgresConnectionSource: BridgesPoolSource {
                 password: self.db.host.password,
                 logger: logger
             ).flatMapErrorThrowing { error in
-                _ = conn.close()
+                let _: EventLoopFuture<Void> = conn.close()
                 throw error
             }.map { conn }
         }


### PR DESCRIPTION
An update was issued where a property of close() was altered and now requires a more specific void declaration.
